### PR TITLE
Update `ons_deaths` table

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -77,7 +77,7 @@ dataset.stp = ordered_regs.practice_stp
 
 # Death
 dataset.died_date=patients.date_of_death
-dataset.died_date_ons=ons_deaths.sort_by(ons_deaths.date).last_for_patient().date
+dataset.died_date_ons = ons_deaths.date
 
 # Date of comorbidities (first match before EIA code)
 def first_comorbidity_in_period(dx_codelist):


### PR DESCRIPTION
The `ons_deaths` table is now a `PatientFrame` (with one row per patient) so it is no longer needed to select one event per patient. The `ons_deaths` table now includes the earliest registered death for each patient.